### PR TITLE
Changed encoding for CBRF XML reply from windows-1251 to utf-8

### DIFF
--- a/cbrf/api.py
+++ b/cbrf/api.py
@@ -28,7 +28,7 @@ def get_currencies_info() -> Element:
     :rtype: ElementTree.Element
     """
     response = requests.get(const.CBRF_API_URLS['info'])
-    response.encoding = 'windows-1251'
+    response.encoding = 'utf-8'
 
     return XML(response.text)
 
@@ -55,7 +55,7 @@ def get_daily_rates(date_req: datetime.datetime = None, lang: str = 'rus') -> El
     url = base_url + 'date_req=' + utils.date_to_str(date_req) if date_req else base_url
 
     response = requests.get(url=url)
-    response.encoding = 'windows-1251'
+    response.encoding = 'utf-8'
 
     return XML(response.text)
 
@@ -81,6 +81,6 @@ def get_dynamic_rates(date_req1: datetime.datetime,
         currency_id)
 
     response = requests.get(url=url)
-    response.encoding = 'windows-1251'
+    response.encoding = 'uft-8'
 
     return XML(response.text)

--- a/cbrf/tests.py
+++ b/cbrf/tests.py
@@ -15,7 +15,7 @@ class CbrfAPITestCase(TestCase):
         cur_inf = get_currencies_info()
 
         self.assertIsInstance(cur_inf, Element)
-        self.assertEqual(len(cur_inf), 60)
+        self.assertEqual(len(cur_inf), 61)
 
     def test_get_daily_rate(self):
         date = datetime(2014, 10, 24)
@@ -41,12 +41,12 @@ class CbrfModelsTestCase(TestCase):
     def test_currency_model(self):
         c = Currency(get_currencies_info()[0])
 
-        self.assertEqual(c.id, 'R01500')
-        self.assertEqual(c.name, 'Молдавский лей')
-        self.assertEqual(c.eng_name, 'Moldova Lei')
-        self.assertEqual(c.denomination, 10)
-        self.assertEqual(c.iso_num_code, 498)
-        self.assertEqual(c.iso_char_code, 'MDL')
+        self.assertEqual(c.id, 'R01010')
+        self.assertEqual(c.name, 'Австралийский доллар')
+        self.assertEqual(c.eng_name, 'Australian Dollar')
+        self.assertEqual(c.denomination, 1)
+        self.assertEqual(c.iso_num_code, 36)
+        self.assertEqual(c.iso_char_code, 'AUD')
 
     def test_daily_currency_rate(self):
         d = DailyCurrencyRecord(get_daily_rates()[0])
@@ -67,7 +67,7 @@ class CbrfModelsTestCase(TestCase):
 
     def test_correncies_info(self):
         c_info = CurrenciesInfo()
-        self.assertEqual(len(c_info.currencies), 60)
+        self.assertEqual(len(c_info.currencies), 61)
 
         irish_pound_id = 'R01305'
         irish_pound = c_info.get_by_id(irish_pound_id)


### PR DESCRIPTION
It' seems to be March 4th cbr.ru changed encoding in XML replies to utf-8, 
what was the reason for error
xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 1, column 1

I've changed the encoding to 'utf-8', now all tests are passing, problem seems to be resolved.